### PR TITLE
support for Django 2.0 added

### DIFF
--- a/singlemodeladmin/__init__.py
+++ b/singlemodeladmin/__init__.py
@@ -1,7 +1,10 @@
 from django.contrib import admin, messages
 from django.core.exceptions import MultipleObjectsReturned
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
 
 
 class SingleModelAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Django 2.0 moved its `reverse` to `django.urls`. Its been deprecated since Django 1.10.